### PR TITLE
Automate serverless deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ target
 
 # Serverless directories
 .serverless
+
+# For hidden environment variables in local dev env
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 language: java
+
 jdk:
 - oraclejdk8
+
+env:
+  - NODE_VERSION="8"
+
+before_install:
+  - nvm install $NODE_VERSION
+  - node --version
+  - npm --version
+
+install:
+  - npm install -g serverless
+
+after_script:
+  - ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,20 @@
-#!/bin/sh
+#!/bin/bash
+set -e
 
-./gradlew build && sls deploy
+BRANCH=${TRAVIS_BRANCH:-$(git rev-parse --abbrev-ref HEAD)} 
+
+if [[ $BRANCH == 'master' ]]; then
+  STAGE="prod"
+elif [[ $BRANCH == 'develop' ]]; then
+  STAGE="dev"
+fi
+
+if [ -z ${STAGE+x} ]; then
+  echo "Not deploying changes";
+  exit 0;
+fi
+
+echo "Deploying from branch $BRANCH to stage $STAGE"
+
+./gradlew build &&
+sls deploy --stage $STAGE --region $AWS_REGION

--- a/picker-data-_star_-eu-west-2-policy.json
+++ b/picker-data-_star_-eu-west-2-policy.json
@@ -1,0 +1,103 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:ValidateTemplate"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:CreateUploadBucket",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResource",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:UpdateStack",
+        "cloudformation:DescribeStacks"
+      ],
+      "Resource": [
+        "arn:aws:cloudformation:eu-west-2:*:stack/picker-data-*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:Get*",
+        "lambda:List*",
+        "lambda:CreateFunction"
+      ],
+      "Resource": [
+        "arn:aws:lambda:eu-west-2:*:function:picker-data-*-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:DeleteObject",
+        "s3:DeleteBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::picker-data*serverlessdeploymentbucket*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:AddPermission",
+        "lambda:CreateAlias",
+        "lambda:DeleteFunction",
+        "lambda:InvokeFunction",
+        "lambda:PublishVersion",
+        "lambda:RemovePermission",
+        "lambda:Update*"
+      ],
+      "Resource": [
+        "arn:aws:lambda:eu-west-2:*:function:picker-data-*-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:GET",
+        "apigateway:POST",
+        "apigateway:PUT",
+        "apigateway:DELETE"
+      ],
+      "Resource": [
+        "arn:aws:apigateway:eu-west-2::/restapis*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:PassRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/picker-data-*-eu-west-2-lambdaRole"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "events:Put*",
+        "events:Remove*",
+        "events:Delete*"
+      ],
+      "Resource": [
+        "arn:aws:events:*:*:rule/picker-data-*-eu-west-2"
+      ]
+    }
+  ]
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: generate-picker-data-file
+service: picker-data
 
 frameworkVersion: ">=1.2.0 <2.0.0"
 


### PR DESCRIPTION
This updates the `deploy.sh` script to work on Travis. When someone pushes to master, it will automatically deploy a new version of the scripts to production.

TODO:

- [x] Update .travis.yml
- [x] Update README