### PR TITLE
Disable Welsh translations for canonical nodes

### DIFF
--- a/src/main/java/uk/gov/Generator.java
+++ b/src/main/java/uk/gov/Generator.java
@@ -94,17 +94,17 @@ public class Generator {
 					resultNode.set("nym:" + code, codeNode);
 				}
 
-				String welshName = record.get("Welsh");
-				if (welshName != null) {
-					String englishName = resultNode.get(key).get("names").get("en-GB").textValue();
-					ObjectNode replacedCountryNode = createEntryNode(
-						englishName, welshName,
-						true, true,
-						new String[]{}
-					);
-
-					resultNode.set(key, replacedCountryNode);
-				}
+				// String welshName = record.get("Welsh");
+				// if (welshName != null) {
+				// 	String englishName = resultNode.get(key).get("names").get("en-GB").textValue();
+				// 	ObjectNode replacedCountryNode = createEntryNode(
+				// 		englishName, welshName,
+				// 		true, true,
+				// 		new String[]{}
+				// 	);
+				//
+				// 	resultNode.set(key, replacedCountryNode);
+				// }
 
 				// Any and all of these field names can be out of bounds.
 				String passportNyms = "";

--- a/src/test/java/uk/gov/Fixtures.java
+++ b/src/test/java/uk/gov/Fixtures.java
@@ -370,17 +370,17 @@ public class Fixtures {
 	}
 
 	public static String graphWithSynonymsOnlyGb() throws Exception {
-		String[] graphEntries = {graphJsonGbWithCy, graphJsonNymUKGBNI, graphJsonNymBrtain, graphJsonNymGB, graphJsonNymUK};
+		String[] graphEntries = {graphJsonGb, graphJsonNymUKGBNI, graphJsonNymBrtain, graphJsonNymGB, graphJsonNymUK};
 		return prettyJson(joinJsonEntries(graphEntries));
 	}
 
 	public static String graphWithSynonymsOnlyGbDe() throws Exception {
-		String[] graphEntries = {graphJsonGbWithCy, graphJsonNymUKGBNI, graphJsonNymBrtain, graphJsonNymGB, graphJsonNymUK, graphJsonDeWithCy, graphJsonNymFRG, graphJsonNymDeutschland, graphJsonNymDE, graphJsonNymBundesrepublik};
+		String[] graphEntries = {graphJsonGb, graphJsonNymUKGBNI, graphJsonNymBrtain, graphJsonNymGB, graphJsonNymUK, graphJsonDe, graphJsonNymFRG, graphJsonNymDeutschland, graphJsonNymDE, graphJsonNymBundesrepublik};
 		return prettyJson(joinJsonEntries(graphEntries));
 	}
 
 	public static String graphThreeRegistersWithCsv() throws Exception {
-		String[] graphEntries = {graphJsonGbWithCy, graphJsonNymUKGBNI, graphJsonNymBrtain, graphJsonNymGB, graphJsonNymUK, graphJsonDeWithCy, graphJsonNymFRG, graphJsonNymDeutschland, graphJsonNymDE, graphJsonNymBundesrepublik, graphJsonPr, graphJsonWls};
+		String[] graphEntries = {graphJsonGb, graphJsonNymUKGBNI, graphJsonNymBrtain, graphJsonNymGB, graphJsonNymUK, graphJsonDe, graphJsonNymFRG, graphJsonNymDeutschland, graphJsonNymDE, graphJsonNymBundesrepublik, graphJsonPr, graphJsonWls};
 		return prettyJson(joinJsonEntries(graphEntries));
 	}
 }


### PR DESCRIPTION
This appears to create duplicate nodes. Disabling it for now as we can always return to fully flesh it out later, as Welsh support needs more work regardless of this.